### PR TITLE
Recommend 기능 내부 구조 개선

### DIFF
--- a/BreezeRead/server/main.py
+++ b/BreezeRead/server/main.py
@@ -129,7 +129,7 @@ def recommend_age_gender(
             title=n.title, 
             link=n.link, 
             thumbnail=n.thumbnail) 
-            for n in news_objs]
+            for n in news_objs["news"]]
     )
 @app.get("/health")
 def health():

--- a/BreezeRead/server/recommend.py
+++ b/BreezeRead/server/recommend.py
@@ -347,7 +347,7 @@ def recommend_news_with_age_gender(url, g, ages):
     # 1️⃣ 뉴스 본문 가져오기
     text = get_naver_news_content(url)
     if not text or "본문을 찾을 수 없습니다." in text:
-        return []
+        return {"keyword_groups": [], "news": []}
 
     # 2️⃣ 키워드 추출
     tfidf_keywords = extract_keywords_tfidf(text)
@@ -357,7 +357,7 @@ def recommend_news_with_age_gender(url, g, ages):
     # 3️⃣ 데이터랩에서 검색량 기준 가장 인기 group 선택
     top_group_data = get_preference_result(keyword_groups, g, ages)
     if not top_group_data:
-        return []
+        return {"keyword_groups": [], "news": []}
 
     # 4️⃣ groupName + 첫 키워드 조합 → 검색어
     main_keyword = f"{top_group_data['groupName']} {top_group_data['keywords'][0]}"
@@ -372,6 +372,13 @@ def recommend_news_with_age_gender(url, g, ages):
     hc.close()
 
     items = list(fromstring(resBody).iter("item"))[:3]
+        # Error handling for HTTP status and XML parsing
+    if res.status != 200:
+        return []
+    try:
+        items = list(fromstring(resBody).iter("item"))[:3]
+    except Exception:
+        return []
 
     # 6️⃣ NewsArticle 객체 생성
     news_objects = []

--- a/BreezeRead/server/recommend.py
+++ b/BreezeRead/server/recommend.py
@@ -291,7 +291,7 @@ def recommend_news_from_url(url: str):
     """
     text = get_naver_news_content(url)
     if not text or "본문을 찾을 수 없습니다." in text:
-        return []
+        return {"keyword_groups": [], "news": []}
 
     tfidf_keywords = extract_keywords_tfidf(text)
     textrank_keywords = extract_keywords_textrank(text)
@@ -382,9 +382,10 @@ def recommend_news_with_age_gender(url, g, ages):
         news_objects.append(NewsArticle(title, link, thumbnail))  # NewsArticle 사용
 
     return {
-        "keyword_groups": main_keyword,
+        "keyword_groups": [top_group_data],
         "news": news_objects
     }
+
 
 # =========================
 # CLI 테스트용


### PR DESCRIPTION
copilot이 추천한 recommend_news_from_url,recommend_news_with_age_gender함수 최종 출력 결과를 통일하고 main_keyword이 리스트 형태로 불러오게 수정했으며 main.py에서 반환하는것도 news를 리스트 형태로 불러오게 수정했습니다