### PR TITLE
recommend.py JVM 초기화 문제 해결

### DIFF
--- a/BreezeRead/server/recommend.py
+++ b/BreezeRead/server/recommend.py
@@ -11,6 +11,9 @@ from bs4 import BeautifulSoup
 from sklearn.feature_extraction.text import TfidfVectorizer
 from konlpy.tag import Okt
 import networkx as nx
+
+OKT_TAGGER = Okt()
+
 '''
 recommend.py 기능 핵심요약 
 
@@ -103,8 +106,7 @@ def extract_keywords_tfidf(text: str, top_n: int = 6):
     Returns:
         [(키워드, 점수), ...] 형태 리스트
     """
-    okt = Okt()
-    tokens = [t for t in okt.nouns(text) if len(t) > 1]
+    tokens = [t for t in OKT_TAGGER.nouns(text) if len(t) > 1]
     tfidf_vectorizer = TfidfVectorizer()
     tfidf_matrix = tfidf_vectorizer.fit_transform([" ".join(tokens)])
     feature_names = tfidf_vectorizer.get_feature_names_out()
@@ -126,8 +128,7 @@ def extract_keywords_textrank(text: str, top_n: int = 6, window_size: int = 4, d
     Returns:
         [(키워드, 점수), ...] 형태 리스트
     """
-    okt = Okt()
-    words = [w for w in okt.nouns(text) if len(w) > 1]
+    words = [w for w in OKT_TAGGER.nouns(text) if len(w) > 1]
     graph = nx.Graph()
     for i, word in enumerate(words):
         for j in range(i+1, min(i+window_size, len(words))):


### PR DESCRIPTION
Closes #45
## 구현 내용
1. 키워드 추출 함수 내부에서 Okt() 객체를 생성하는 것을 전역 변수로 하여 단 한 번만 초기화하도록 한다.

## 결과
1. recommend_news_from_url 과 recommend_news_with_age_gender 함수가 호출될 때마다 OKt() 가 호출되어 있던 상황에서, 딱 한 번만 전역으로 호출하여 성능의 향상을 원했다.
2. 메모리 이미지, cpu 등을 조절하고 1번 과정을 수정한 후 실행했으나, 큰 차이가 없다.
3. JVM이 무겁고, 콜드 스타트에도 약하다.