### PR TITLE
fix recommend to adjust filter

### DIFF
--- a/BreezeRead/.gitignore
+++ b/BreezeRead/.gitignore
@@ -2,4 +2,11 @@
 datalab.py
 crawling.py
 t_datalab.py
+c_datalab.py
+c_datalab2.py
+c_datalab2.py
+c_predatalab_result.txt
+c_predatalab.py
+c_datalab_result.txt
+c_datalab_result2.txt
 tf-idf.py

--- a/BreezeRead/server/recommend.py
+++ b/BreezeRead/server/recommend.py
@@ -54,8 +54,8 @@ python 실행파일.py
 load_dotenv()
 
 # 환경변수 불러오기
-CLIENT_ID = os.environ.get("client_id")
-CLIENT_SECRET = os.environ.get("client_secret")
+CLIENT_ID = os.environ.get("CLIENT_ID")
+CLIENT_SECRET = os.environ.get("CLIENT_SECRET")
 NAVER_CLIENT_ID = os.environ.get("NAVER_CLIENT_ID")
 NAVER_CLIENT_SECRET = os.environ.get("NAVER_CLIENT_SECRET")
 
@@ -160,6 +160,47 @@ def create_keyword_groups(tfidf_keywords, textrank_keywords):
     textrank_keywords_list = [w for w, s in textrank_keywords[1:]]
     keyword_groups.append({'groupName': textrank_groupName, 'keywords': textrank_keywords_list})
     return keyword_groups
+
+def merge_keywords(tfidf_keywords, textrank_keywords, top_n=20):
+    """
+    TF-IDF와 TextRank 키워드를 상위 N개씩 가져와
+    중복 제거 후 하나의 키워드 리스트로 병합한다.
+
+    Returns:
+        ["키워드1", "키워드2", ...]
+    """
+
+    # TF-IDF 상위 top_n
+    tfidf_list = [w for w, s in tfidf_keywords[:top_n]]
+
+    # TextRank 상위 top_n
+    textrank_list = [w for w, s in textrank_keywords[:top_n]]
+
+    # 합치고 중복 제거
+    merged = list(set(tfidf_list + textrank_list))
+
+    return merged
+
+def make_keyword_groups_for_datalab(keyword_list):
+    """
+    keyword_list에서 최대 5개의 키워드를 사용해
+    groupName = 키워드
+    keywords = [키워드]
+    형식으로 변환하는 함수
+    """
+    groups = []
+
+    # 최대 5개만 사용
+    limited_keywords = keyword_list[:5]
+
+    for kw in limited_keywords:
+        groups.append({
+            "groupName": kw,
+            "keywords": [kw]
+        })
+
+    return groups
+
     
 # =========================
 # 연령대별, 나이대별 선호도 조사 
@@ -366,10 +407,11 @@ def recommend_news_with_age_gender(url, g, ages):
     # 2️⃣ 키워드 추출
     tfidf_keywords = extract_keywords_tfidf(text)
     textrank_keywords = extract_keywords_textrank(text)
-    keyword_groups = create_keyword_groups(tfidf_keywords, textrank_keywords)
+    keywords = merge_keywords(tfidf_keywords, textrank_keywords)
+    keywordGroups = make_keyword_groups_for_datalab(keywords)
 
     # 3️⃣ 데이터랩에서 검색량 기준 가장 인기 group 선택
-    top_group_data = get_preference_result(keyword_groups, g, ages)
+    top_group_data = get_preference_result(keywordGroups, g, ages)
     if not top_group_data:
         return {"keyword_groups": [], "news": []}
 


### PR DESCRIPTION
기존 로직 - tf-idf에서 추출된 키워드 그룹이랑 textrank에서 추출된 키워드 그룹을 비교
-> 거의 필터링 결과변화가 나타나지 않음

----
### 수정 사항
recommend.py에서 연령/성별 별 선호도 조사 할때
tf-idf에서 추출된 키워드 그룹이랑 textrank에서 추출된 키워드 그룹을 합친뒤
** 그룹안에있는 키워드 별로 **
조회수를 조회함
<img width="495" height="720" alt="image" src="https://github.com/user-attachments/assets/46b8e50a-3fc3-49f6-a096-b7f1ff1ea91d" />
결과 확인해보니 그래도 성별/연령대 별로 미묘한 결과가 드러남

---
ps) 이 내용 기반으로 현재 네이버 뉴스 도메인에서 크롤링가능한 기사 12000개 가량의 기사별로 얼마나 추천 결과가 드러나는지 확인후 보고서 결과에 기재할 예정. 